### PR TITLE
Fixed Unit Test class

### DIFF
--- a/tests/CommentCtrlTest.php
+++ b/tests/CommentCtrlTest.php
@@ -10,6 +10,9 @@ class CommentCtrlTest extends TestCase{
         //Get a User that made a comment and see if the Commentcontroller registers that
         $kommentar = Kommentar::where('commentable_type','=','App\\Block')->first();
 
+        if (empty($kommentar))
+            return true;
+
         $id = $kommentar->commentable_id;
 
 


### PR DESCRIPTION
Fixed a small mistake with the unit Test. The test failed because it could be possible that no comment for a block was generated in the testdata. Therefor we have to check if data exists and if not skip this step.
